### PR TITLE
Stop cardtype selection from clearing checkout data.

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/dibs_flexwin.js
+++ b/view/frontend/web/js/view/payment/method-renderer/dibs_flexwin.js
@@ -82,7 +82,14 @@ define(
                 var obj = storage.get('checkout-data');
                 obj.paytypeId = event.target.id;
                 this.getDibsPaytype(obj.paytypeId);
-                storage.set('checkout-data', obj);
+                /**
+                 * The below instruction causes checkout data to be removed when selecting a payment method
+                 * since `obj` refers to a function and not the actual data.
+                 *
+                 * @todo: set payTypeId properly on the observable data and not the observable function
+                 */
+                // storage.set('checkout-data', obj);
+
                 return true;
             },
 


### PR DESCRIPTION
When the user selects a cardtype on the payment step, all checkout data is removed from localstorage (addresses, shipping method, etc) and the data is lost when refreshing the page after selecting a cardtype for payment.

This happens because `storage.set` was being called with a function (the knockout observable wrapper) instead of the actual data.

The data modeling needs a more in-depth refactoring (as it's currently a mess), but this will stop the bug from affecting users for now.